### PR TITLE
Improve replace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,10 +238,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -248,6 +375,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.101",
  "typify",
+ "url",
  "xdg",
 ]
 
@@ -261,6 +389,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -279,6 +413,21 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -413,6 +562,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +608,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +636,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -518,6 +700,23 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -599,7 +798,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "xdg"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]

--- a/json-schema-catalog-rs/Cargo.toml
+++ b/json-schema-catalog-rs/Cargo.toml
@@ -15,6 +15,7 @@ json_schema = "1.7.5"
 schemars = "0.8.22"
 serde = "1.0.219"
 serde_json = "1.0.140"
+url = "2.5.4"
 xdg = "3.0.0"
 
 

--- a/json-schema-catalog-rs/src/main.rs
+++ b/json-schema-catalog-rs/src/main.rs
@@ -171,7 +171,7 @@ impl ReplaceCommand {
         match value {
             serde_json::Value::Object(map) => {
                 for (key, value) in map.iter_mut() {
-                    if key == "$ref" || key == "$schema" {
+                    if key == "$ref" {
                         let value_str = value.as_str().ok_or_else(|| {
                             anyhow::anyhow!(
                                 "Expected string value for {}, but got {:?}",

--- a/json-schema-catalog-rs/src/main.rs
+++ b/json-schema-catalog-rs/src/main.rs
@@ -172,18 +172,66 @@ impl ReplaceCommand {
             serde_json::Value::Object(map) => {
                 for (key, value) in map.iter_mut() {
                     if key == "$ref" || key == "$schema" {
-                        match context.index.get_path(value.as_str().unwrap()) {
-                            Some(path) => {
+                        let value_str = value.as_str().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Expected string value for {}, but got {:?}",
+                                key,
+                                value
+                            )
+                        })?;
+                        let base_url = url::Url::parse("file:///")
+                            .with_context(|| "Failed to parse base URL for file scheme")?;
+
+                        let url: url::Url = url::Url::options()
+                            .base_url(Some(&base_url))
+                            .parse(value_str)
+                            .with_context(|| format!("Failed to parse URI: {}", value_str))?;
+
+                        let lookup_result = {
+                            let mut schema_url = url.clone();
+                            schema_url.set_fragment(Some(""));
+                            context.index.get_path(schema_url.as_str()).or_else(|| {
+                                // Maybe the # was forgotten, in either the reference or the catalog
+                                match schema_url.fragment() {
+                                    Some("") => {
+                                        schema_url.set_fragment(None);
+                                    }
+                                    None {} => {
+                                        schema_url.set_fragment(Some(""));
+                                    }
+                                    _ => {}
+                                }
+                                context.index.get_path(schema_url.as_str())
+                            })
+                        };
+
+                        match lookup_result {
+                            Some(location) => {
+                                let mut location_url = url::Url::from_file_path(&location)
+                                    .map_err(|()| {
+                                        anyhow::format_err!(
+                                            "Failed to convert catalog path to URL: {}",
+                                            &location
+                                        )
+                                    })?;
+
+                                location_url.set_fragment(url.fragment());
+
+                                let location_str = location_url.as_str();
+
                                 if self.verbose {
                                     eprintln!(
                                         "Replacing {} field, old: {} new: {}",
-                                        key, value, path
+                                        key, value, location_str
                                     );
                                 }
-                                *value = serde_json::Value::String(path);
+
+                                *value = serde_json::Value::String(location_str.to_string());
                             }
                             None {} => {
-                                if !self.ignore_unknown {
+                                if url.scheme() == "file" {
+                                    // already local, great!
+                                } else if !self.ignore_unknown {
                                     status = Err(anyhow::format_err!(
                                         "Could not find schema with id {}",
                                         value.as_str().unwrap()

--- a/pkgs-lib-tests.nix
+++ b/pkgs-lib-tests.nix
@@ -36,6 +36,9 @@ rec {
           "type": "object",
           "oneOf": [
             {
+              "$ref": "https://json-schema.org/draft-07/schema#"
+            },
+            {
               "$ref": "https://json-schema.org/draft-07/schema#/definitions/yolo"
             },
             {
@@ -47,10 +50,13 @@ rec {
         cat >example.json.expected <<"EOF"
         {
           "$id": "https://example.com/schemas/integration-test.json",
-          "$schema": "file://${
-            exampleCatalog.groups."JSON Schema"."https://json-schema.org/draft-07/schema#"
-          }#",
+          "$schema": "https://json-schema.org/draft-07/schema#",
           "oneOf": [
+            {
+              "$ref": "file://${
+                exampleCatalog.groups."JSON Schema"."https://json-schema.org/draft-07/schema#"
+              }#"
+            },
             {
               "$ref": "file://${
                 exampleCatalog.groups."JSON Schema"."https://json-schema.org/draft-07/schema#"
@@ -64,6 +70,9 @@ rec {
           "type": "object"
         }
         EOF
+        ( set -x;
+          ! grep '##' example.json.expected
+        )
 
         json-schema-catalog replace --verbose example.json > example.json.out
 

--- a/pkgs-lib-tests.nix
+++ b/pkgs-lib-tests.nix
@@ -33,13 +33,33 @@ rec {
           "$id": "https://example.com/schemas/integration-test.json",
           "$schema": "https://json-schema.org/draft-07/schema#",
           "title": "Integration Test",
-          "type": "object"
+          "type": "object",
+          "oneOf": [
+            {
+              "$ref": "https://json-schema.org/draft-07/schema#/definitions/yolo"
+            },
+            {
+              "$ref": "./foo.json#/definitions/bar"
+            }
+          ]
         }
         EOF
         cat >example.json.expected <<"EOF"
         {
           "$id": "https://example.com/schemas/integration-test.json",
-          "$schema": "${exampleCatalog.groups."JSON Schema"."https://json-schema.org/draft-07/schema#"}",
+          "$schema": "file://${
+            exampleCatalog.groups."JSON Schema"."https://json-schema.org/draft-07/schema#"
+          }#",
+          "oneOf": [
+            {
+              "$ref": "file://${
+                exampleCatalog.groups."JSON Schema"."https://json-schema.org/draft-07/schema#"
+              }#/definitions/yolo"
+            },
+            {
+              "$ref": "./foo.json#/definitions/bar"
+            }
+          ],
           "title": "Integration Test",
           "type": "object"
         }


### PR DESCRIPTION
- Leave `"$schema"` as is
  > Replacing these is not helpful, as this would just confuse most tooling that needs to bring its own understanding of schemas anyway. "$ref" is the useful thing to replace.
- Make it understand URLs, matching regardless of fragment, preserving fragment

Fragments in the catalog `location` fields probably don't behave well, but that's a weird thing to do?